### PR TITLE
feat: upvote, downvote and count votes

### DIFF
--- a/frontend/api/boardService.tsx
+++ b/frontend/api/boardService.tsx
@@ -19,12 +19,8 @@ export const updateBoardRequest = ({ board }: UpdateBoardDto): Promise<BoardType
   return fetchData(`/boards/${board._id}`, { method: "PUT", data: board });
 };
 
-export const getBoardRequest = (
-  id: string,
-  token?: string,
-  serverSide?: boolean
-): Promise<BoardType> => {
-  return fetchData<BoardType>(`/boards/${id}`, { token, serverSide });
+export const getBoardRequest = (id: string, serverSide?: boolean): Promise<BoardType> => {
+  return fetchData<BoardType>(`/boards/${id}`, { serverSide });
 };
 
 export const getBoardsRequest = (): Promise<BoardType[]> => {

--- a/frontend/api/boardService.tsx
+++ b/frontend/api/boardService.tsx
@@ -8,6 +8,7 @@ import UpdateCardDto from "../types/card/updateCard.dto";
 import AddCommentDto from "../types/comment/addComment.dto";
 import DeleteCommentDto from "../types/comment/deleteComment.dto";
 import UpdateCommentDto from "../types/comment/updateComment.dto";
+import VoteDto from "../types/board/vote/vote.dto";
 // #region BOARD
 
 export const createBoardRequest = (newBoard: BoardToAdd): Promise<BoardType> => {
@@ -18,8 +19,12 @@ export const updateBoardRequest = ({ board }: UpdateBoardDto): Promise<BoardType
   return fetchData(`/boards/${board._id}`, { method: "PUT", data: board });
 };
 
-export const getBoardRequest = (id: string): Promise<BoardType> => {
-  return fetchData<BoardType>(`/boards/${id}`);
+export const getBoardRequest = (
+  id: string,
+  token?: string,
+  serverSide?: boolean
+): Promise<BoardType> => {
+  return fetchData<BoardType>(`/boards/${id}`, { token, serverSide });
 };
 
 export const getBoardsRequest = (): Promise<BoardType[]> => {
@@ -96,4 +101,24 @@ export const deleteCommentRequest = (deleteCommentDto: DeleteCommentDto): Promis
   );
 };
 
+// #endregion
+
+// #region VOTES
+export const addVoteRequest = (voteDto: VoteDto): Promise<BoardType> => {
+  return fetchData<BoardType>(
+    voteDto.isCardGroup
+      ? `/boards/${voteDto.boardId}/card/${voteDto.cardId}/vote`
+      : `/boards/${voteDto.boardId}/card/${voteDto.cardId}/items/${voteDto.cardItemId}/vote`,
+    { method: "POST", data: voteDto }
+  );
+};
+
+export const deleteVoteRequest = (voteDto: VoteDto): Promise<BoardType> => {
+  return fetchData<BoardType>(
+    voteDto.isCardGroup
+      ? `/boards/${voteDto.boardId}/card/${voteDto.cardId}/vote`
+      : `/boards/${voteDto.boardId}/card/${voteDto.cardId}/items/${voteDto.cardItemId}/vote`,
+    { method: "DELETE", data: voteDto }
+  );
+};
 // #endregion

--- a/frontend/components/Board/Card/AddCard.tsx
+++ b/frontend/components/Board/Card/AddCard.tsx
@@ -9,6 +9,7 @@ import BlurEvent from "../../../types/events/blurEvent";
 import Button from "../../Primitives/Button";
 import Flex from "../../Primitives/Flex";
 import ResizableTextArea from "../../Primitives/ResizableTextArea";
+import isEmpty from "../../../utils/isEmpty";
 
 const ActionButton = styled(Button, { borderRadius: "$round" });
 
@@ -41,7 +42,7 @@ const AddCard = React.memo<AddCardProps>(({ colId, boardId, socketId }) => {
   const handleFocus = () => setIsClicked(true);
 
   const handleAddCard = () => {
-    if (text?.length === 0) {
+    if (isEmpty(text)) {
       ToastMessage("Card text cannot be empty!", "error");
       return;
     }

--- a/frontend/components/Board/Card/CardFooter.tsx
+++ b/frontend/components/Board/Card/CardFooter.tsx
@@ -48,30 +48,28 @@ const CardFooter = React.memo<FooterProps>(({ boardId, userId, socketId, card })
 
   const handleDeleteVote = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.stopPropagation();
-    if (!isEmpty(votesOfUserInThisCard)) {
-      ToastMessage(`You have ${maxVotes - actualBoardVotes + 1} remaining`, "info");
-      deleteVote.mutate({
-        boardId,
-        cardId: card._id,
-        socketId,
-        cardItemId,
-        isCardGroup: !cardItemId,
-      });
-    }
+    if (isEmpty(votesOfUserInThisCard)) return;
+    ToastMessage(`You have ${maxVotes - actualBoardVotes + 1} remaining`, "info");
+    deleteVote.mutate({
+      boardId,
+      cardId: card._id,
+      socketId,
+      cardItemId,
+      isCardGroup: !cardItemId,
+    });
   };
 
   const handleAddVote = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.stopPropagation();
-    if (actualBoardVotes < maxVotes) {
-      ToastMessage(`You have ${maxVotes - actualBoardVotes - 1} remaining`, "info");
-      addVote.mutate({
-        boardId,
-        cardId: card._id,
-        socketId,
-        cardItemId,
-        isCardGroup: !cardItemId,
-      });
-    }
+    if (actualBoardVotes >= maxVotes) return;
+    ToastMessage(`You have ${maxVotes - actualBoardVotes - 1} remaining`, "info");
+    addVote.mutate({
+      boardId,
+      cardId: card._id,
+      socketId,
+      cardItemId,
+      isCardGroup: !cardItemId,
+    });
   };
 
   return (

--- a/frontend/components/Board/Card/CardFooter.tsx
+++ b/frontend/components/Board/Card/CardFooter.tsx
@@ -1,13 +1,27 @@
 import React from "react";
-import { ChatBubbleIcon } from "@modulz/radix-icons";
+import {
+  ChatBubbleIcon,
+  ThickArrowUpIcon,
+  PlusCircledIcon,
+  MinusCircledIcon,
+} from "@modulz/radix-icons";
 import Flex from "../../Primitives/Flex";
 import Text from "../../Primitives/Text";
 import { styled } from "../../../stitches.config";
 import CardType from "../../../types/card/card";
 import { getCommentsFromCardGroup } from "../../../helper/board/comments";
 import Button from "../../Primitives/Button";
+import useBoard from "../../../hooks/useBoard";
+import { useAppSelector } from "../../../store/hooks";
+import { getCardVotes } from "../../../helper/board/votes";
+import { maxBoardVotes } from "../../../store/store";
+import ToastMessage from "../../../utils/toast";
+import isEmpty from "../../../utils/isEmpty";
 
 const StyledChatBubbleIcon = styled(ChatBubbleIcon, { size: "100%" });
+const StyledPlusIcon = styled(PlusCircledIcon, { size: "100%" });
+const StyledMinusIcon = styled(MinusCircledIcon, { size: "100%" });
+const StyledCThickArrowUpIcon = styled(ThickArrowUpIcon, { size: "100%" });
 
 interface FooterProps {
   boardId: string;
@@ -16,9 +30,49 @@ interface FooterProps {
   card: CardType;
 }
 
-const CardFooter = React.memo<FooterProps>(({ card }) => {
+const CardFooter = React.memo<FooterProps>(({ boardId, userId, socketId, card }) => {
+  const { addVote, deleteVote } = useBoard({ autoFetchBoard: false, autoFetchBoards: false });
+
+  const actualBoardVotes = useAppSelector((state) => state.board.votes);
+
+  const cardItemId = card.items.length === 1 ? card.items[0]._id : undefined;
+
+  const votesInThisCard = card.items.length === 1 ? card.items[0].votes : getCardVotes(card);
+
+  const votesOfUserInThisCard = votesInThisCard.filter((vote) => vote === userId).length;
+
   const comments =
     card.items.length === 1 ? card.items[0].comments : getCommentsFromCardGroup(card);
+
+  const maxVotes = maxBoardVotes();
+
+  const handleDeleteVote = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.stopPropagation();
+    if (!isEmpty(votesOfUserInThisCard)) {
+      ToastMessage(`You have ${maxVotes - actualBoardVotes + 1} remaining`, "info");
+      deleteVote.mutate({
+        boardId,
+        cardId: card._id,
+        socketId,
+        cardItemId,
+        isCardGroup: !cardItemId,
+      });
+    }
+  };
+
+  const handleAddVote = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.stopPropagation();
+    if (actualBoardVotes < maxVotes) {
+      ToastMessage(`You have ${maxVotes - actualBoardVotes - 1} remaining`, "info");
+      addVote.mutate({
+        boardId,
+        cardId: card._id,
+        socketId,
+        cardItemId,
+        isCardGroup: !cardItemId,
+      });
+    }
+  };
 
   return (
     <Flex align="center" justify="end" css={{ mt: "auto" }} gap="6">
@@ -32,6 +86,37 @@ const CardFooter = React.memo<FooterProps>(({ card }) => {
         <StyledChatBubbleIcon />
       </Button>
       <Text>{comments.length}</Text>
+      <Button
+        css={{
+          size: "$20",
+          cursor: "grab",
+        }}
+      >
+        <StyledCThickArrowUpIcon />
+      </Button>
+
+      <Text noMargin>{votesInThisCard.length}</Text>
+
+      <Button
+        css={{ size: "$20" }}
+        onClick={handleAddVote}
+        disabled={actualBoardVotes === maxVotes}
+      >
+        <StyledPlusIcon />
+      </Button>
+
+      {!isEmpty(votesOfUserInThisCard) && (
+        <>
+          <Text>{votesOfUserInThisCard}</Text>
+          <Button
+            css={{ size: "$20" }}
+            onClick={handleDeleteVote}
+            disabled={isEmpty(actualBoardVotes)}
+          >
+            <StyledMinusIcon />
+          </Button>
+        </>
+      )}
     </Flex>
   );
 });

--- a/frontend/components/HOC/requireAuthentication.tsx
+++ b/frontend/components/HOC/requireAuthentication.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { getSession } from "next-auth/react";
+import { setHeaderToken } from "../../utils/fetchData";
 import { AUTH_ROUTE } from "../../utils/routes";
 
 function requireAuthentication(gssp: GetServerSideProps) {
@@ -20,6 +21,8 @@ function requireAuthentication(gssp: GetServerSideProps) {
         },
       };
     }
+
+    setHeaderToken(true, session.accessToken);
 
     return gssp(ctx);
   };

--- a/frontend/components/Title/InputTitle.tsx
+++ b/frontend/components/Title/InputTitle.tsx
@@ -8,6 +8,7 @@ import BoardType from "../../types/board/board";
 import Flex from "../Primitives/Flex";
 import ToastMessage from "../../utils/toast";
 import ClickEvent from "../../types/events/clickEvent";
+import isEmpty from "../../utils/isEmpty";
 
 const ActionButton = styled(Button, {});
 
@@ -26,7 +27,7 @@ const InputTitle: React.FC<InputTitleBoard> = ({ board, onClickEdit, isBoardPage
   const handleUpdateTitle = (event: ClickEvent<HTMLButtonElement, MouseEvent>) => {
     event.stopPropagation();
     onClickEdit(false);
-    if (title.length === 0) {
+    if (isEmpty(title)) {
       ToastMessage("Title cannot be empty", "error");
       return;
     }

--- a/frontend/helper/board/votes.ts
+++ b/frontend/helper/board/votes.ts
@@ -1,0 +1,47 @@
+import BoardType from "../../types/board/board";
+import CardType from "../../types/card/card";
+
+const countVotes = (board: BoardType, userId: string) => {
+  let votes = 0;
+  if (userId && board) {
+    for (let i = 0; i < board.columns.length; i++) {
+      const column = board.columns[i];
+      for (let j = 0; j < column.cards.length; j++) {
+        const card = column.cards[j];
+        if (card.votes.includes(userId)) {
+          for (let k = 0; k < card.votes.length; k++) {
+            if (card.votes[k] === userId) {
+              votes++;
+            }
+          }
+        }
+        for (let x = 0; x < card.items.length; x++) {
+          const item = card.items[x];
+          if (item.votes.includes(userId)) {
+            for (let y = 0; y < item.votes.length; y++) {
+              if (item.votes[y] === userId) {
+                votes++;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return votes;
+};
+
+export const getCardVotes = (card: CardType) => {
+  let votes = [...card.votes];
+  card.items.forEach((item) => {
+    votes = votes.concat(item.votes);
+  });
+  return votes;
+};
+
+export const votesOfUserInCard = (card: CardType, userId: string) => {
+  const votes = getCardVotes(card);
+  return votes.includes(userId);
+};
+
+export default countVotes;

--- a/frontend/helper/board/votes.ts
+++ b/frontend/helper/board/votes.ts
@@ -2,33 +2,24 @@ import BoardType from "../../types/board/board";
 import CardType from "../../types/card/card";
 
 const countVotes = (board: BoardType, userId: string) => {
-  let votes = 0;
-  if (userId && board) {
-    for (let i = 0; i < board.columns.length; i++) {
-      const column = board.columns[i];
-      for (let j = 0; j < column.cards.length; j++) {
-        const card = column.cards[j];
-        if (card.votes.includes(userId)) {
-          for (let k = 0; k < card.votes.length; k++) {
-            if (card.votes[k] === userId) {
-              votes++;
-            }
-          }
-        }
-        for (let x = 0; x < card.items.length; x++) {
-          const item = card.items[x];
-          if (item.votes.includes(userId)) {
-            for (let y = 0; y < item.votes.length; y++) {
-              if (item.votes[y] === userId) {
-                votes++;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  return votes;
+  if (!userId || !board) return 0;
+  return board.columns.reduce((acc, column) => {
+    column.cards.forEach((card) => {
+      card.votes
+        .filter((vote) => vote === userId)
+        .forEach(() => {
+          acc++;
+        });
+      card.items.forEach((item) => {
+        item.votes
+          .filter((vote) => vote === userId)
+          .forEach(() => {
+            acc++;
+          });
+      });
+    });
+    return acc;
+  }, 0);
 };
 
 export const getCardVotes = (card: CardType) => {

--- a/frontend/hooks/useBoard.tsx
+++ b/frontend/hooks/useBoard.tsx
@@ -16,9 +16,11 @@ import {
   addCommentRequest,
   deleteCommentRequest,
   updateCommentRequest,
+  addVoteRequest,
+  deleteVoteRequest,
 } from "../api/boardService";
 import UseBoardType from "../types/board/useBoard";
-import { setChangesBoard } from "../store/slicer/boardSlicer";
+import { decrementVote, incrementVote, setChangesBoard } from "../store/slicer/boardSlicer";
 import { useAppDispatch } from "../store/hooks";
 
 interface AutoFetchProps {
@@ -159,6 +161,34 @@ const useBoard = ({
 
   // #endregion
 
+  // #region VOTE
+  // #region VOTES
+
+  const addVote = useMutation(addVoteRequest, {
+    onSuccess: (board: BoardType) => {
+      dispatch(incrementVote());
+      dispatch(setChangesBoard({ board, userId }));
+    },
+    onError: () => {
+      fetchBoard.refetch();
+      ToastMessage("Vote not inserted!", "error");
+    },
+  });
+
+  const deleteVote = useMutation(deleteVoteRequest, {
+    onSuccess: (board: BoardType) => {
+      dispatch(decrementVote());
+      dispatch(setChangesBoard({ board, userId }));
+    },
+    onError: () => {
+      fetchBoard.refetch();
+      ToastMessage("Vote not deleted!", "error");
+    },
+  });
+
+  // #endregion
+
+  // #endregion
   return {
     fetchBoard,
     fetchBoards,
@@ -172,6 +202,8 @@ const useBoard = ({
     addCommentInCard,
     deleteComment,
     updateComment,
+    addVote,
+    deleteVote,
   };
 };
 

--- a/frontend/pages/boards/[boardId].tsx
+++ b/frontend/pages/boards/[boardId].tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps } from "next";
 import { QueryClient, dehydrate } from "react-query";
 import { useRouter } from "next/router";
 import { io, Socket } from "socket.io-client";
-import { getSession, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { DragDropContext, DropResult, ResponderProvided } from "react-beautiful-dnd";
 import Flex from "../../components/Primitives/Flex";
 import Text from "../../components/Primitives/Text";
@@ -67,10 +67,9 @@ const ColumnList = React.memo<ColumnListProps>(({ columns, boardId, userId, sock
 
 export const getServerSideProps: GetServerSideProps = requireAuthentication(async (context) => {
   const { boardId } = context.query;
-  const session = await getSession(context);
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery(["board", { id: boardId }], () =>
-    getBoardRequest(boardId as string, session?.accessToken, true)
+    getBoardRequest(boardId as string, true)
   );
 
   return {

--- a/frontend/pages/boards/[boardId].tsx
+++ b/frontend/pages/boards/[boardId].tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import { GetServerSideProps } from "next";
+import { QueryClient, dehydrate } from "react-query";
 import { useRouter } from "next/router";
 import { io, Socket } from "socket.io-client";
-import { useSession } from "next-auth/react";
+import { getSession, useSession } from "next-auth/react";
 import { DragDropContext, DropResult, ResponderProvided } from "react-beautiful-dnd";
 import Flex from "../../components/Primitives/Flex";
 import Text from "../../components/Primitives/Text";
@@ -21,6 +22,7 @@ import {
 import BoardType from "../../types/board/board";
 import UpdateCardPositionDto from "../../types/card/updateCardPosition.dto";
 import requireAuthentication from "../../components/HOC/requireAuthentication";
+import { getBoardRequest } from "../../api/boardService";
 
 const Container = styled(Flex, {
   alignItems: "flex-start",
@@ -63,9 +65,18 @@ const ColumnList = React.memo<ColumnListProps>(({ columns, boardId, userId, sock
   );
 });
 
-export const getServerSideProps: GetServerSideProps = requireAuthentication(async () => {
+export const getServerSideProps: GetServerSideProps = requireAuthentication(async (context) => {
+  const { boardId } = context.query;
+  const session = await getSession(context);
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery(["board", { id: boardId }], () =>
+    getBoardRequest(boardId as string, session?.accessToken, true)
+  );
+
   return {
-    props: {},
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
   };
 });
 
@@ -86,9 +97,9 @@ const Board: React.FC = () => {
 
   useEffect(() => {
     if (data && !board) {
-      dispatch(setBoard(data));
+      dispatch(setBoard({ board: data, userId }));
     }
-  }, [board, data, dispatch]);
+  }, [board, data, dispatch, userId]);
 
   useEffect(() => {
     const newSocket: Socket = io(NEXT_PUBLIC_BACKEND_URL ?? "http://127.0.0.1:3200");

--- a/frontend/store/slicer/boardSlicer.tsx
+++ b/frontend/store/slicer/boardSlicer.tsx
@@ -6,9 +6,11 @@ import { Nullable } from "../../types/common";
 import BoardChanges from "../../types/board/boardChanges";
 import UpdateCardPositionDto from "../../types/card/updateCardPosition.dto";
 import { handleUpdateCardPosition } from "../../helper/board/transformBoard";
+import countVotes from "../../helper/board/votes";
 
 interface BoardState {
   value: Nullable<BoardType>;
+  votes: number;
 }
 
 interface BoardAction {
@@ -18,21 +20,25 @@ interface BoardAction {
 
 const initialState: BoardState = {
   value: undefined,
+  votes: 0,
 };
 
 export const boardSlice = createSlice({
   name: "board",
   initialState,
   reducers: {
-    setBoard: (state, action: PayloadAction<Nullable<BoardType>>) => {
-      state.value = action.payload;
+    setBoard: (state, action: PayloadAction<BoardAction>) => {
+      const { board, userId } = action.payload;
+      state.value = board;
+      if (userId) state.votes = countVotes(board, userId);
     },
     setChangesBoard: (state, action: PayloadAction<BoardAction>) => {
-      const { board } = action.payload;
+      const { board, userId } = action.payload;
       if (state.value) {
         const operation = jsonPatch.compare(state.value, board);
         if (operation.length > 0)
           state.value = jsonPatch.applyPatch(state.value, operation).newDocument;
+        if (userId) state.votes = countVotes(board, userId);
       }
     },
     clearBoard: (state) => {
@@ -47,10 +53,26 @@ export const boardSlice = createSlice({
         state.value = newBoard;
       }
     },
+    setVotes: (state, action: PayloadAction<number>) => {
+      state.votes = action.payload;
+    },
+    incrementVote: (state) => {
+      state.votes += 1;
+    },
+    decrementVote: (state) => {
+      state.votes -= 1;
+    },
   },
 });
 
-export const { setBoard, setNewCardPosition, setChangesBoard, clearBoard } = boardSlice.actions;
+export const {
+  setBoard,
+  setNewCardPosition,
+  setChangesBoard,
+  clearBoard,
+  incrementVote,
+  decrementVote,
+} = boardSlice.actions;
 
 export const selectBoard = (state: RootState): BoardState => state.board;
 

--- a/frontend/store/store.tsx
+++ b/frontend/store/store.tsx
@@ -9,6 +9,8 @@ const store = configureStore({
 
 export default store;
 
+export const actualVotes = () => store.getState().board.votes;
+export const maxBoardVotes = () => store.getState().board.value?.maxVotes ?? 0;
 export const selectBoard = (state: RootState) => state.board;
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/frontend/types/board/useBoard.ts
+++ b/frontend/types/board/useBoard.ts
@@ -8,6 +8,7 @@ import DeleteCardDto from "../card/deleteCard.dto";
 import AddCommentDto from "../comment/addComment.dto";
 import DeleteCommentDto from "../comment/deleteComment.dto";
 import UpdateCommentDto from "../comment/updateComment.dto";
+import VoteDto from "./vote/vote.dto";
 
 export default interface UseBoardType {
   createBoard: UseMutationResult<BoardType, unknown, BoardToAdd, unknown>;
@@ -22,4 +23,6 @@ export default interface UseBoardType {
   addCommentInCard: UseMutationResult<BoardType, unknown, AddCommentDto, unknown>;
   updateComment: UseMutationResult<BoardType, unknown, UpdateCommentDto, unknown>;
   deleteComment: UseMutationResult<BoardType, unknown, DeleteCommentDto, unknown>;
+  addVote: UseMutationResult<BoardType, unknown, VoteDto, unknown>;
+  deleteVote: UseMutationResult<BoardType, unknown, VoteDto, unknown>;
 }

--- a/frontend/types/board/vote/vote.dto.ts
+++ b/frontend/types/board/vote/vote.dto.ts
@@ -1,0 +1,7 @@
+export default interface VoteDto {
+  cardId: string;
+  cardItemId?: string;
+  boardId: string;
+  socketId?: string;
+  isCardGroup: boolean;
+}

--- a/frontend/utils/fetchData.tsx
+++ b/frontend/utils/fetchData.tsx
@@ -15,8 +15,7 @@ instance.interceptors.request.use(async (config) => {
   const { url, headers } = config;
   if (url && headers && !nonNeededToken.includes(url)) {
     const session = await getSession();
-
-    headers.Authorization = `Bearer ${session?.accessToken}`;
+    if (session) headers.Authorization = `Bearer ${session?.accessToken}`;
   }
 
   return config;

--- a/frontend/utils/fetchData.tsx
+++ b/frontend/utils/fetchData.tsx
@@ -28,6 +28,14 @@ export const serverSideInstance = axios.create({
   },
 });
 
+export const setHeaderToken = (serverSide: boolean, token: string | undefined) => {
+  if (serverSide) {
+    serverSideInstance.defaults.headers.common.Authorization = `Bearer ${token}`;
+  } else {
+    instance.defaults.headers.common.Authorization = `Bearer ${token}`;
+  }
+};
+
 type Options = {
   token?: string;
   serverSide?: boolean;


### PR DESCRIPTION
<!--
#88
-->

Relates to #88

## Proposed Changes

  - Upvote and downvote in the card footer
  - Enable/disable voting based on board max votes
  - Request methods to call the api in order to create or remove a vote
  - Votes count methods and they are already prepared to include the card group votes
 
This pull request is intended to close #88
<!--
Mention people who discussed this issue previously
@someone
-->
