### PR TITLE
refactor: create board users from team,  create team user, get teams methods

### DIFF
--- a/backend/src/libs/enum/board.roles.ts
+++ b/backend/src/libs/enum/board.roles.ts
@@ -2,4 +2,5 @@ export enum BoardRoles {
   OWNER = 'owner',
   MEMBER = 'member',
   RESPONSIBLE = 'responsible',
+  STAKEHOLDER = 'stakeholder',
 }

--- a/backend/src/libs/utils/ignored_users.json
+++ b/backend/src/libs/utils/ignored_users.json
@@ -1,0 +1,1 @@
+["nuno1@gmail.com"]

--- a/backend/src/modules/boards/controller/boards.controller.ts
+++ b/backend/src/modules/boards/controller/boards.controller.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../libs/exceptions/messages';
 import { BaseParam } from '../../../libs/dto/param/base.param';
 import { PaginationParams } from '../../../libs/dto/param/pagination.params';
+import * as StakeholdersData from '../../../libs/utils/ignored_users.json';
 
 @Controller('boards')
 export default class BoardsController {
@@ -91,6 +92,12 @@ export default class BoardsController {
     if (!board) throw new NotFoundException(BOARD_NOT_FOUND);
 
     return board;
+  }
+
+  @UseGuards(JwtAuthenticationGuard)
+  @Get('/stakeholders/all')
+  getStakeholders() {
+    return StakeholdersData as unknown as string[];
   }
 
   @UseGuards(JwtAuthenticationGuard)

--- a/backend/src/modules/boards/dto/board.dto.ts
+++ b/backend/src/modules/boards/dto/board.dto.ts
@@ -6,8 +6,6 @@ import {
   ValidateNested,
   IsOptional,
   IsBoolean,
-  IsNumber,
-  ValidateIf,
   IsMongoId,
   Validate,
 } from 'class-validator';
@@ -37,23 +35,41 @@ export default class BoardDto {
   @IsBoolean()
   isPublic!: boolean;
 
-  @ValidateIf((o) => o.isPublic === false)
   @IsNotEmpty()
-  @Transform(({ value }: TransformFnParams) => value.trim())
-  password?: string;
+  @IsString()
+  @IsOptional()
+  maxVotes?: string | null;
 
   @IsNotEmpty()
-  @IsNumber()
-  maxVotes!: number;
+  @IsString()
+  @IsOptional()
+  maxUsers?: string | null;
+
+  @IsNotEmpty()
+  @IsString()
+  @IsOptional()
+  maxTeams?: string | null;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  hideCards!: boolean;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  hideVotes!: boolean;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  postAnonymously!: boolean;
 
   @IsOptional()
   @ValidateNested({ each: true })
-  dividedBoards?: BoardDto[];
+  dividedBoards!: BoardDto[];
 
   @IsOptional()
   @IsMongoId()
   @IsString()
-  team?: string;
+  team?: string | null;
 
   @IsOptional()
   socketId?: string;
@@ -61,4 +77,12 @@ export default class BoardDto {
   @IsOptional()
   @Validate(CheckUniqueUsers)
   users!: BoardUserDto[];
+
+  @IsNotEmpty()
+  @IsBoolean()
+  recurrent?: boolean;
+
+  @IsNotEmpty()
+  @IsBoolean()
+  isSubBoard?: boolean;
 }

--- a/backend/src/modules/boards/dto/board.user.dto.ts
+++ b/backend/src/modules/boards/dto/board.user.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsMongoId,
   IsEnum,
+  IsNumber,
 } from 'class-validator';
 import { BoardRoles } from '../../../libs/enum/board.roles';
 
@@ -21,4 +22,8 @@ export default class BoardUserDto {
   @IsString()
   @IsNotEmpty()
   user!: string;
+
+  @IsOptional()
+  @IsNumber()
+  votesCount?: number;
 }

--- a/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
+++ b/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
@@ -21,6 +21,14 @@ export interface GetBoardApplicationInterface {
   getBoard(
     boardId: string,
     userId: string,
-  ): Promise<LeanDocument<BoardDocument> | null>;
+  ): Promise<
+    | { board: LeanDocument<BoardDocument> }
+    | null
+    | {
+        board: LeanDocument<BoardDocument>;
+        mainBoardData: LeanDocument<BoardDocument>;
+      }
+    | null
+  >;
   countBoards(userId: string): Promise<number>;
 }

--- a/backend/src/modules/boards/interfaces/findQuery.ts
+++ b/backend/src/modules/boards/interfaces/findQuery.ts
@@ -1,5 +1,5 @@
 import { LeanDocument } from 'mongoose';
-import { TeamUserDocument } from '../../teams/schemas/team.user.schema';
+import { TeamDocument } from '../../teams/schemas/teams.schema';
 
 export type QueryType = {
   $and: (
@@ -20,7 +20,7 @@ export type QueryType = {
             }
           | {
               team: {
-                $in?: LeanDocument<TeamUserDocument>[];
+                $in?: LeanDocument<TeamDocument>[];
                 $ne?: undefined | null;
               };
               _id?: undefined;

--- a/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
+++ b/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
@@ -24,6 +24,14 @@ export interface GetBoardServiceInterface {
   getBoard(
     boardId: string,
     userId: string,
-  ): Promise<LeanDocument<BoardDocument> | null>;
+  ): Promise<
+    | { board: LeanDocument<BoardDocument> }
+    | null
+    | {
+        board: LeanDocument<BoardDocument>;
+        mainBoardData: LeanDocument<BoardDocument>;
+      }
+    | null
+  >;
   countBoards(userId: string): Promise<number>;
 }

--- a/backend/src/modules/boards/schemas/board.schema.ts
+++ b/backend/src/modules/boards/schemas/board.schema.ts
@@ -9,6 +9,9 @@ export type BoardDocument = Board & Document;
 
 @Schema({
   timestamps: true,
+  toJSON: {
+    virtuals: true,
+  },
 })
 export default class Board {
   @Prop({ nullable: false })
@@ -17,14 +20,11 @@ export default class Board {
   @Prop({ nullable: false })
   isPublic!: boolean;
 
-  @Prop({ nullable: true })
-  password?: string;
-
   @Prop({ type: SchemaTypes.ObjectId, ref: 'User' })
   submitedByUser!: ObjectId;
 
-  @Prop({ nullable: false })
-  maxVotes!: number;
+  @Prop({ type: Date, nullable: true, default: null })
+  submitedAt!: Date;
 
   @Prop({ nullable: false, type: [ColumnSchema] })
   columns!: ColumnDocument[];
@@ -43,11 +43,23 @@ export default class Board {
   @Prop({ type: SchemaTypes.ObjectId, ref: 'User' })
   createdBy!: User | ObjectId;
 
-  @Prop({ default: false })
+  @Prop({ type: Boolean, default: false })
   recurrent!: boolean;
 
-  @Prop({ default: false })
+  @Prop({ type: Boolean, default: false })
   isSubBoard!: boolean;
+
+  @Prop({ type: String, nullable: true, default: null })
+  maxVotes?: string;
+
+  @Prop({ type: Boolean, nullable: false, default: false })
+  hideCards?: boolean;
+
+  @Prop({ type: Boolean, nullable: false, default: false })
+  hideVotes?: boolean;
+
+  @Prop({ type: Boolean, nullable: false, default: false })
+  postAnonymously?: boolean;
 }
 
 export const BoardSchema = SchemaFactory.createForClass(Board);

--- a/backend/src/modules/boards/schemas/board.user.schema.ts
+++ b/backend/src/modules/boards/schemas/board.user.schema.ts
@@ -14,7 +14,12 @@ export default class BoardUser {
   @Prop({
     nullable: false,
     type: String,
-    enum: [BoardRoles.RESPONSIBLE, BoardRoles.MEMBER, BoardRoles.OWNER],
+    enum: [
+      BoardRoles.RESPONSIBLE,
+      BoardRoles.MEMBER,
+      BoardRoles.OWNER,
+      BoardRoles.STAKEHOLDER,
+    ],
   })
   role!: string;
 

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { GetTeamService } from '../../teams/interfaces/services/get.team.service.interface';
+import { GetTeamServiceInterface } from '../../teams/interfaces/services/get.team.service.interface';
 import * as Team from '../../teams/interfaces/types';
 import { QueryType } from '../interfaces/findQuery';
 import { GetBoardServiceInterface } from '../interfaces/services/get.board.service.interface';
@@ -15,7 +15,7 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
     @InjectModel(BoardUser.name)
     private boardUserModel: Model<BoardUserDocument>,
     @Inject(Team.TYPES.services.GetTeamService)
-    private getTeamService: GetTeamService,
+    private getTeamService: GetTeamServiceInterface,
   ) {}
 
   getAllBoardsIdsOfUser(userId: string) {

--- a/backend/src/modules/teams/applications/create.team.application.ts
+++ b/backend/src/modules/teams/applications/create.team.application.ts
@@ -1,15 +1,20 @@
 import { Inject, Injectable } from '@nestjs/common';
 import TeamDto from '../dto/team.dto';
-import { CreateTeamApplication } from '../interfaces/applications/create.team.application.interface';
-import { CreateTeamService } from '../interfaces/services/create.team.service.interface';
+import teamUserDto from '../dto/team.user.dto';
+import { CreateTeamApplicationInterface } from '../interfaces/applications/create.team.application.interface';
+import { CreateTeamServiceInterface } from '../interfaces/services/create.team.service.interface';
 import { TYPES } from '../interfaces/types';
 
 @Injectable()
-export class CreateTeamApplicationImpl implements CreateTeamApplication {
+export class CreateTeamApplication implements CreateTeamApplicationInterface {
   constructor(
     @Inject(TYPES.services.CreateTeamService)
-    private createTeamService: CreateTeamService,
+    private createTeamService: CreateTeamServiceInterface,
   ) {}
+
+  createTeamUser(teamUser: teamUserDto) {
+    return this.createTeamUser(teamUser);
+  }
 
   create(teamData: TeamDto, userId: string) {
     return this.createTeamService.create(teamData, userId);

--- a/backend/src/modules/teams/applications/get.team.application.ts
+++ b/backend/src/modules/teams/applications/get.team.application.ts
@@ -1,16 +1,24 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { GetTeamApplicationInterface } from '../interfaces/applications/get.team.application.interface';
-import { GetTeamService } from '../interfaces/services/get.team.service.interface';
+import { GetTeamServiceInterface } from '../interfaces/services/get.team.service.interface';
 import { TYPES } from '../interfaces/types';
 
 @Injectable()
-export class GetTeamApplicationImpl implements GetTeamApplicationInterface {
+export class GetTeamApplication implements GetTeamApplicationInterface {
   constructor(
     @Inject(TYPES.services.GetTeamService)
-    private getTeamService: GetTeamService,
+    private getTeamService: GetTeamServiceInterface,
   ) {}
 
   countTeams(userId: string) {
     return this.getTeamService.countTeams(userId);
+  }
+
+  getAllTeams() {
+    return this.getTeamService.getAllTeams();
+  }
+
+  getTeamsOfUser(userId: string) {
+    return this.getTeamService.getTeamsOfUser(userId);
   }
 }

--- a/backend/src/modules/teams/controller/team.controller.ts
+++ b/backend/src/modules/teams/controller/team.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Get,
   Inject,
   Post,
   Req,
@@ -11,14 +12,18 @@ import { INSERT_FAILED } from '../../../libs/exceptions/messages';
 import JwtAuthenticationGuard from '../../../libs/guards/jwtAuth.guard';
 import RequestWithUser from '../../../libs/interfaces/requestWithUser.interface';
 import TeamDto from '../dto/team.dto';
-import { CreateTeamApplication } from '../interfaces/applications/create.team.application.interface';
+import TeamUserDto from '../dto/team.user.dto';
+import { CreateTeamApplicationInterface } from '../interfaces/applications/create.team.application.interface';
+import { GetTeamApplicationInterface } from '../interfaces/applications/get.team.application.interface';
 import { TYPES } from '../interfaces/types';
 
 @Controller('teams')
 export default class TeamsController {
   constructor(
     @Inject(TYPES.applications.CreateTeamApplication)
-    private createTeamApp: CreateTeamApplication,
+    private createTeamApp: CreateTeamApplicationInterface,
+    @Inject(TYPES.applications.GetTeamApplication)
+    private getTeamApp: GetTeamApplicationInterface,
   ) {}
 
   @UseGuards(JwtAuthenticationGuard)
@@ -27,5 +32,25 @@ export default class TeamsController {
     const team = await this.createTeamApp.create(teamData, request.user._id);
     if (!team) throw new BadRequestException(INSERT_FAILED);
     return team;
+  }
+
+  @UseGuards(JwtAuthenticationGuard)
+  @Post()
+  async createTeamUser(@Body() teamData: TeamUserDto) {
+    const team = await this.createTeamApp.createTeamUser(teamData);
+    if (!team) throw new BadRequestException(INSERT_FAILED);
+    return team;
+  }
+
+  @UseGuards(JwtAuthenticationGuard)
+  @Get()
+  getAllTeams() {
+    return this.getTeamApp.getAllTeams();
+  }
+
+  @UseGuards(JwtAuthenticationGuard)
+  @Get('/member')
+  getTeamsOfUser(@Req() request: RequestWithUser) {
+    return this.getTeamApp.getTeamsOfUser(request.user._id);
   }
 }

--- a/backend/src/modules/teams/interfaces/applications/create.team.application.interface.ts
+++ b/backend/src/modules/teams/interfaces/applications/create.team.application.interface.ts
@@ -1,6 +1,9 @@
 import TeamDto from '../../dto/team.dto';
+import TeamUserDto from '../../dto/team.user.dto';
+import { TeamUserDocument } from '../../schemas/team.user.schema';
 import { TeamDocument } from '../../schemas/teams.schema';
 
-export interface CreateTeamApplication {
+export interface CreateTeamApplicationInterface {
+  createTeamUser(teamUser: TeamUserDto): Promise<TeamUserDocument>;
   create(teamData: TeamDto, userId: string): Promise<TeamDocument>;
 }

--- a/backend/src/modules/teams/interfaces/applications/get.team.application.interface.ts
+++ b/backend/src/modules/teams/interfaces/applications/get.team.application.interface.ts
@@ -1,3 +1,8 @@
+import { LeanDocument } from 'mongoose';
+import { TeamDocument } from '../../schemas/teams.schema';
+
 export interface GetTeamApplicationInterface {
   countTeams(userId: string): Promise<number>;
+  getAllTeams(): Promise<LeanDocument<TeamDocument>[]>;
+  getTeamsOfUser(userId: string): Promise<LeanDocument<TeamDocument>[]>;
 }

--- a/backend/src/modules/teams/interfaces/services/create.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/create.team.service.interface.ts
@@ -1,6 +1,9 @@
 import TeamDto from '../../dto/team.dto';
+import TeamUserDto from '../../dto/team.user.dto';
+import { TeamUserDocument } from '../../schemas/team.user.schema';
 import { TeamDocument } from '../../schemas/teams.schema';
 
-export interface CreateTeamService {
+export interface CreateTeamServiceInterface {
   create(teamData: TeamDto, userId: string): Promise<TeamDocument>;
+  createTeamUser(teamUser: TeamUserDto): Promise<TeamUserDocument>;
 }

--- a/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
@@ -1,11 +1,15 @@
 import { LeanDocument } from 'mongoose';
 import { TeamUserDocument } from '../../schemas/team.user.schema';
+import { TeamDocument } from '../../schemas/teams.schema';
 
-export interface GetTeamService {
+export interface GetTeamServiceInterface {
   countTeams(userId: string): Promise<number>;
-  getTeamsOfUser(userId: string): Promise<LeanDocument<TeamUserDocument>[]>;
+  getTeamsOfUser(userId: string): Promise<LeanDocument<TeamDocument>[]>;
+  getTeam(teamId: string): Promise<LeanDocument<TeamDocument> | null>;
+  getUsersOfTeam(teamId: string): Promise<LeanDocument<TeamUserDocument>[]>;
   getTeamUser(
     userId: string,
     boardId: string,
   ): Promise<LeanDocument<TeamUserDocument> | null>;
+  getAllTeams(): Promise<LeanDocument<TeamDocument>[]>;
 }

--- a/backend/src/modules/teams/providers.ts
+++ b/backend/src/modules/teams/providers.ts
@@ -1,5 +1,5 @@
-import { CreateTeamApplicationImpl } from './applications/create.team.application';
-import { GetTeamApplicationImpl } from './applications/get.team.application';
+import { CreateTeamApplication } from './applications/create.team.application';
+import { GetTeamApplication } from './applications/get.team.application';
 import { TYPES } from './interfaces/types';
 import CreateTeamServiceImpl from './services/create.team.service';
 import GetTeamServiceImpl from './services/get.team.service';
@@ -11,7 +11,7 @@ export const createTeamService = {
 
 export const createTeamApplication = {
   provide: TYPES.applications.CreateTeamApplication,
-  useClass: CreateTeamApplicationImpl,
+  useClass: CreateTeamApplication,
 };
 
 export const getTeamService = {
@@ -21,5 +21,5 @@ export const getTeamService = {
 
 export const getTeamApplication = {
   provide: TYPES.applications.GetTeamApplication,
-  useClass: GetTeamApplicationImpl,
+  useClass: GetTeamApplication,
 };

--- a/backend/src/modules/teams/services/create.team.service.ts
+++ b/backend/src/modules/teams/services/create.team.service.ts
@@ -5,12 +5,14 @@ import { TeamRoles } from '../../../libs/enum/team.roles';
 import isEmpty from '../../../libs/utils/isEmpty';
 import TeamDto from '../dto/team.dto';
 import TeamUserDto from '../dto/team.user.dto';
-import { CreateTeamService } from '../interfaces/services/create.team.service.interface';
+import { CreateTeamServiceInterface } from '../interfaces/services/create.team.service.interface';
 import TeamUser, { TeamUserDocument } from '../schemas/team.user.schema';
 import Team, { TeamDocument } from '../schemas/teams.schema';
 
 @Injectable()
-export default class CreateTeamServiceImpl implements CreateTeamService {
+export default class CreateTeamServiceImpl
+  implements CreateTeamServiceInterface
+{
   constructor(
     @InjectModel(Team.name) private teamModel: Model<TeamDocument>,
     @InjectModel(TeamUser.name) private teamUserModel: Model<TeamUserDocument>,
@@ -43,5 +45,9 @@ export default class CreateTeamServiceImpl implements CreateTeamService {
     }
 
     return newTeam.populate('users');
+  }
+
+  async createTeamUser(teamUser: TeamUserDto) {
+    return this.teamUserModel.create({ ...teamUser });
   }
 }

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { GetTeamService } from '../interfaces/services/get.team.service.interface';
+import { GetTeamServiceInterface } from '../interfaces/services/get.team.service.interface';
 import TeamUser, { TeamUserDocument } from '../schemas/team.user.schema';
 import Team, { TeamDocument } from '../schemas/teams.schema';
 
 @Injectable()
-export default class GetTeamServiceImpl implements GetTeamService {
+export default class GetTeamService implements GetTeamServiceInterface {
   constructor(
     @InjectModel(Team.name) private teamModel: Model<TeamDocument>,
     @InjectModel(TeamUser.name) private teamUserModel: Model<TeamUserDocument>,
@@ -20,10 +20,18 @@ export default class GetTeamServiceImpl implements GetTeamService {
       .exec();
   }
 
-  getTeamsOfUser(userId: string) {
-    return this.teamUserModel
+  getTeam(teamId: string) {
+    return this.teamModel.findById(teamId).lean().exec();
+  }
+
+  async getTeamsOfUser(userId: string) {
+    const teams = await this.teamUserModel
       .find({ user: userId })
-      .distinct('team')
+      .distinct('team');
+    return this.teamModel
+      .find({ _id: { $in: teams } })
+      .select('_id name')
+      .populate({ path: 'users', select: '_id user role' })
       .lean()
       .exec();
   }
@@ -31,6 +39,32 @@ export default class GetTeamServiceImpl implements GetTeamService {
   getTeamUser(userId: string, teamId: string) {
     return this.teamUserModel
       .findOne({ user: userId, team: teamId })
+      .lean()
+      .exec();
+  }
+
+  getAllTeams() {
+    return this.teamModel
+      .find()
+      .populate({
+        path: 'users',
+        select: 'user role',
+        populate: {
+          path: 'user',
+          select: '_id firstName lastName email joinedAt',
+        },
+      })
+      .lean({ virtuals: true })
+      .exec();
+  }
+
+  getUsersOfTeam(teamId: string) {
+    return this.teamUserModel
+      .find({ team: teamId })
+      .populate({
+        path: 'user',
+        select: '_id firstName lastName email',
+      })
       .lean()
       .exec();
   }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #137

## Proposed Changes

  - create the `board_users` in the main board that are participating in the board team
  - get stakeholders method
  - get teams of user and users of team
  - get board
  
<!--
Mention people who discussed this issue previously
@someone
-->
